### PR TITLE
add parsers to `compare` and `plot` benchs

### DIFF
--- a/dynamo/README.md
+++ b/dynamo/README.md
@@ -37,7 +37,7 @@ To maintain the sanity of this repository, we can maintain the same dir structur
 
 ### Config the benchmark run
 
-This is done a YAML file as example the [bench_config.yaml](./bench_config.yaml). This file is where the benchmark experiments are defined. First, we have a `global` level, and subsequently the config for each operation itself.
+This is done by a YAML file as example the [bench_config.yaml](./bench_config.yaml). This file is where the benchmark experiments are defined. First, we have a `global` level, and subsequently the config for each operation itself.
 
 - The global level needs to have (as sublevels):
   1. `batch_sizes` a list of batch_sizes (integer) wanted to be tested in the benchmarks.
@@ -46,7 +46,7 @@ This is done a YAML file as example the [bench_config.yaml](./bench_config.yaml)
   1. `import_from` a string with the name of the top level directory with the desired benchmarks. Here, is the  [config/](./config/) directory.
 
 - Subsequently we can add the operations wanted to be bench with their specific arguments.
-  - The name of the operation should match with the relative path under the top level directory. For example, to config a `dilation` bench, which is in [config/geometry/transform/rescale.py](./config/geometry/transform/rescale.py) we will add the name of op as `geometry.transform.rescale`.
+  - The name of the operation should match with the relative path under the top level directory. For example, to config a `rescale` bench, which is in [config/geometry/transform/rescale.py](./config/geometry/transform/rescale.py) we will add the name of op as `geometry.transform.rescale`.
   - Here we can overwrite the `global` configs if necessary.
   - inside of the level of the operation we can add the arguments which will be dispatch to the operation itself.
     - Normal cases we can pass direct the desired argument, as example for rescale we want to pass the `factor` argument. Then we create a list of cases (for rescale a list of integer) to be done the benchmark.

--- a/dynamo/README.md
+++ b/dynamo/README.md
@@ -87,6 +87,11 @@ With all the experiments desired configured in the `YAML` file you can run the r
 $ python runner.py
 ```
 
-The arguments of the runner can be checked with the `--help` argument (running with `$python runner.py --help`). Some of the arguments are:
-- `--config-filename` to define the `YAML` config file, by default the runner will look for `./bench_config.yaml`.
-- `--verbose` to turn on the verbose mode of the dynamo. Also, have `--debug` to set logger to debug level.
+The arguments of the runner can be checked with the `--help` argument (running
+with `$python runner.py --help`). Some of the arguments are:
+- `--config-filename` to define the `YAML` config file, by default the runner
+will look for `./bench_config.yaml`.
+- `--verbose` to turn on the verbose mode of the dynamo. Also, have `--debug`
+to set logger to debug level.
+- `--save-graphs` generate a graph for each operation comparing the benchmarks.
+The graphs will be saved under the directory [out_graphs/]('./out_graphs/').

--- a/dynamo/compare.py
+++ b/dynamo/compare.py
@@ -1,0 +1,72 @@
+from typing import List
+
+import pandas as pd
+from torch.utils.benchmark.utils import common
+from torch.utils.benchmark.utils.compare import Compare as _Comp
+from torch.utils.benchmark.utils.compare import Table
+
+
+class Table_CSV(Table):
+    def render(self) -> str:
+
+        has_warnings = (
+            self._highlight_warnings and any(
+                ri.has_warnings
+                for ri in self.results
+            )
+        )
+
+        string_rows = [['arguments'] + self.column_keys + [
+            'op',
+            'time_unit',
+            'has_warnings',
+            'threads',
+        ]]
+        nt = None
+        for r in self.rows:
+            if r._num_threads is not None:
+                nt = r._num_threads
+            string_rows.append(r.as_column_strings())
+            string_rows[-1] += [
+                self.label, self.time_unit, str(has_warnings),
+                str(nt),
+            ]
+
+        finalized_columns = [';'.join(r).strip() for r in string_rows]
+
+        newline = '\n'
+        return newline.join(finalized_columns)
+
+
+class Compare(_Comp):
+    def _layout(self, results: List[common.Measurement]):
+        table = Table_CSV(
+            results,
+            self._colorize,
+            self._trim_significant_figures,
+            self._highlight_warnings,
+        )
+        return table.render()
+
+    def join_to_df(self):
+        out = self._render()
+        headers = [o.split('\n')[0] for o in out]
+
+        # Check if all headers are equal
+        if headers.count(headers[0]) == len(headers):
+            header = headers[0]
+            content = [o.split('\n')[1:] for o in out]
+            content = [
+                item.split(';') for sublist in content
+                for item in sublist
+            ]
+
+            return pd.DataFrame(
+                columns=header.split(';'),
+                data=content,
+            )
+        else:
+            raise Exception(
+                'Unsupported operation since the headers does'
+                ' not match.',
+            )

--- a/dynamo/plot.py
+++ b/dynamo/plot.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 
 import matplotlib.pyplot as plt

--- a/dynamo/plot.py
+++ b/dynamo/plot.py
@@ -1,0 +1,137 @@
+import matplotlib.pyplot as plt
+import pandas as pd
+from compare import Compare
+from matplotlib.patches import Patch
+from runner import _unpick
+
+
+def _color_op_names(df):
+    def _update_name(row):
+        if row['op'] == 'color.multiple':
+            args = row['arguments'][1:-1].split(',')
+            row['op'] = 'color.' + args[-1].lstrip()
+            row['arguments'] = '[' + ','.join(args[:-1]) + ']'
+        return row
+
+    return df.apply(lambda row: _update_name(row), axis=1)
+
+
+def preprocess(df):
+    # add here the call of the desired function to do something with the df
+    # e.g. fix the color operation because we use a multiple case
+    df = _color_op_names(df)
+
+    df = df.replace(r'^\s*$', None, regex=True)
+
+    return df
+
+
+# Load the results: will be a list of torch Measurement
+results = _unpick('output-benchmark-20230106_173208.pickle')
+
+# Transform into a table
+compare = Compare(results)
+df = compare.join_to_df()
+
+# Preprocess the df
+df = preprocess(df)
+
+
+# Cast the column types
+df['has_warnings'] = df['has_warnings'].replace({'False': False, 'True': True})
+df = df.convert_dtypes()
+
+# Get the module name and the operation itself
+df['op_name'] = df['op'].apply(lambda x: x.split('.')[-1])
+df['module'] = df['op'].apply(lambda x: '.'.join(x.split('.')[:-1]))
+
+# generate a df for each operation
+df_by_op = df.groupby('op_name')
+
+
+def plot(df, name=''):
+    print(f'Working on plot of {name}...')
+
+    if df['has_warnings'].any():
+        print(
+            '\033[1;33m'
+            '(! XX%) Measurement has high variance, where XX is the IQR'
+            ' / median * 100.'
+            '\033[0;0m',
+        )
+
+    _map = {
+        'opencv_cpu': {
+            'idx': 0, 'new_name': 'opencv', 'color': (.627, .627, .627, 1.),
+        },
+        'kornia_cpu': {
+            'idx': 1, 'new_name': 'eager_cpu', 'color': (.745, .725, .859, 1.),
+        },
+        'dynamo_kornia_cpu': {
+            'idx': 2, 'new_name': 'dynamo_cpu', 'color': (.99, .8, .898, 1.),
+        },
+        'kornia_gpu': {
+            'idx': 3, 'new_name': 'eager_gpu', 'color': (.698, .878, .38, .1),
+        },
+        'dynamo_kornia_gpu': {
+            'idx': 4,  'new_name': 'dynamo_gpu',
+            'color': (.741, .494, .745, 1.),
+        },
+    }
+
+    cols = [x for x in df.columns if x not in _map.keys()]
+
+    # Join time into a unique serie
+    _df = pd.DataFrame(columns=cols+['optimizer', 'time', 'old_name'])
+    for k, v in _map.items():
+        if k not in df.columns:
+            continue
+        df_tmp = df[cols + [k]]
+        df_tmp = df_tmp.rename({k: 'time'}, axis='columns')
+        df_tmp['optimizer'] = v['new_name']
+        df_tmp['old_name'] = k
+        _df = pd.concat([_df, df_tmp])
+
+    _df['time'] = _df['time'].astype(float)
+    time_unit = _df['time_unit'].unique()[0]
+
+    _df['label'] = _df['threads'] + ' threads | ' + _df['arguments']
+    _df['_seq'] = _df['old_name'].apply(lambda x: _map[x]['idx'])
+    _df['color'] = _df['old_name'].apply(lambda x: _map[x]['color'])
+    _df = _df.sort_values(['label', '_seq'])
+
+    # Create graph
+    ax = _df.plot.bar(
+        x='label',
+        y='time',
+        color=_df['color'].values.tolist(),
+        legend=True,
+        title=name,
+        ylabel=time_unit,
+        xlabel='arguments',
+        logy=True,
+    )
+
+    # Create legend
+    handles = []
+    _as = []
+    for _, row in _df.iterrows():
+        if row['optimizer'] in _as:
+            continue
+        handles.append(Patch(facecolor=row['color'], label=row['optimizer']))
+        _as.append(row['optimizer'])
+    ax.legend(handles=handles)
+
+    # Add labels to bars
+    ax.bar_label(ax.containers[0])
+
+    # Config plot
+    plt.xticks(rotation=45)
+
+    # show or save
+    plt.show()
+
+
+# Plot each operation
+for op_name, frame in df_by_op:
+    plot(frame, op_name)

--- a/dynamo/plot.py
+++ b/dynamo/plot.py
@@ -27,7 +27,7 @@ def preprocess(df):
 
 
 # Load the results: will be a list of torch Measurement
-results = _unpick('output-benchmark-20230106_173208.pickle')
+results = _unpick('output-benchmark-20230309_235112.pickle')
 
 # Transform into a table
 compare = Compare(results)
@@ -70,10 +70,10 @@ def plot(df, name=''):
         'dynamo_kornia_cpu': {
             'idx': 2, 'new_name': 'dynamo_cpu', 'color': (.99, .8, .898, 1.),
         },
-        'kornia_gpu': {
-            'idx': 3, 'new_name': 'eager_gpu', 'color': (.698, .878, .38, .1),
+        'kornia_cuda': {
+            'idx': 3, 'new_name': 'eager_gpu', 'color': (.698, .878, .38, 1.),
         },
-        'dynamo_kornia_gpu': {
+        'dynamo_kornia_cuda': {
             'idx': 4,  'new_name': 'dynamo_gpu',
             'color': (.741, .494, .745, 1.),
         },

--- a/dynamo/plot.py
+++ b/dynamo/plot.py
@@ -29,6 +29,18 @@ def preprocess(df):
     return df
 
 
+def _format_time(value: float | str, unit: str) -> str:
+    if unit == 'us':
+        if value > 1e5:
+            value = value / 1e6
+            unit = 's'
+        elif value > 1e2:
+            value = value/1e3
+            unit = 'ms'
+
+    return f'{value:.2f} {unit}'
+
+
 def plot(df, name='', save: bool = False, outdir: str = 'out_graphs/'):
     print(f'Working on plot of {name}...')
 
@@ -72,7 +84,7 @@ def plot(df, name='', save: bool = False, outdir: str = 'out_graphs/'):
         _df = pd.concat([_df, df_tmp])
 
     _df['time'] = _df['time'].astype(float)
-    time_unit = f"time ({_df['time_unit'].unique()[0]})"
+    time_unit = _df['time_unit'].unique()[0]
 
     _df['label'] = _df['threads'] + ' threads\n' + _df['arguments']
 
@@ -105,16 +117,21 @@ def plot(df, name='', save: bool = False, outdir: str = 'out_graphs/'):
         logx=True,
     )
     ax.invert_yaxis()
+    ax.margins(0.1)
 
     # Config legend
     ax.legend(fontsize='xx-small')
 
     # Add labels to bars
     for container in ax.containers:
-        ax.bar_label(container, fontsize=5, padding=6, fmt='%.1f')
+        labels = [
+            _format_time(float(v), time_unit)
+            for v in container.datavalues
+        ]
+        ax.bar_label(container, labels=labels, fontsize=5, padding=6)
 
     # Config plot
-    plt.xlabel(time_unit, fontsize='x-small')
+    plt.xlabel(f'Time ({time_unit})', fontsize='x-small')
     plt.ylabel('Argunments', fontsize='x-small')
     plt.xticks(rotation=45, fontsize='xx-small')
     plt.yticks(fontsize='xx-small')

--- a/dynamo/plot.py
+++ b/dynamo/plot.py
@@ -176,7 +176,6 @@ def plot(df, name='', save: bool = False, outdir: str = 'out_graphs/'):
     time_unit = _df['time_unit'].unique()[0]
 
     _df['label'] = _df['threads'] + ' threads\n' + _df['arguments']
-
     _df['label'] = _df['label'].astype('category')
 
     df_pivot = pd.pivot_table(

--- a/dynamo/requirements.txt
+++ b/dynamo/requirements.txt
@@ -1,5 +1,7 @@
 # --extra-index-url https://download.pytorch.org/whl/nightly/cu117
 # torch[dynamo]
 kornia@git+https://github.com/kornia/kornia
+matplotlib
 opencv-python
+pandas
 PyYAML

--- a/dynamo/runner.py
+++ b/dynamo/runner.py
@@ -342,10 +342,7 @@ def run(
 
 def generate_graphs(filename: str) -> int:
     # Load the results: will be a list of torch Measurement
-    results = _unpick(filename)
-
-    graphs_from_results(results)
-
+    graphs_from_results(_unpick(filename))
     return 0
 
 
@@ -409,7 +406,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         sig = generate_graphs(filename=args.output_filename)
 
     return sig
-
 
 if __name__ == '__main__':
     raise SystemExit(main())

--- a/dynamo/runner.py
+++ b/dynamo/runner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import logging
 import pickle
@@ -11,8 +13,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
-from typing import Tuple
-from typing import Union
 
 import numpy as np
 import torch
@@ -52,13 +52,13 @@ def set_op_to_bench(module: str, operator: str, optimizer: Any) -> None:
 
 
 def create_inputs(
-        bs: Optional[int],
+        bs: int | None,
         res: int,
         out_t: str,
         dtype: torch.dtype = torch.float32,
         device: torch.device = torch.device('cpu'),
         RGB: bool = True,
-) -> Union[Tensor, np.ndarray]:
+) -> Tensor | np.ndarray:
 
     if RGB:
         x_tensor = torch.ones((3, res, res), dtype=dtype, device=device)
@@ -76,14 +76,14 @@ def create_inputs(
 
 
 def _iter_cfg(
-        configs: List[Dict[str, Any]],
-) -> Tuple[Dict[str, Any], int, int, int]:
+        configs: list[dict[str, Any]],
+) -> tuple[dict[str, Any], int, int, int]:
     for cfg in configs:
         for bs, res in product(cfg['batch_sizes'], cfg['resolutions']):
             yield cfg, bs, res
 
 
-def _iter_op_device() -> Tuple[str, str, str, Tuple[Any]]:
+def _iter_op_device() -> tuple[str, str, str, tuple[Any]]:
     # TODO: Maybe automate this?
     _iters = [
         ('kornia_op', 'tensor', 'cpu', None),
@@ -110,9 +110,9 @@ def _check_run(
         verbose: bool,
         module: str,
         operator: str,
-        x: Union[Tensor, np.ndarray],
+        x: Tensor | np.ndarray,
         optimizer: Any,
-        **kwargs: Dict[str, Any]
+        **kwargs: dict[str, Any]
 ) -> bool:
     try:
         op = _load_operator(module, operator, optimizer)
@@ -134,8 +134,8 @@ def _check_run(
 
 def _unpack_config_or_load_global(
         config_name: str,
-        data: Dict[str, Any],
-        global_data: Dict[str, Any],
+        data: dict[str, Any],
+        global_data: dict[str, Any],
 ) -> Any:
     if config_name in data:
         return data[config_name]
@@ -144,11 +144,11 @@ def _unpack_config_or_load_global(
 
 
 def create_ones(
-        shape: Tuple[int, ...],
+        shape: tuple[int, ...],
         out_t: str,
         dtype: torch.dtype = torch.float32,
         device: torch.device = torch.device('cpu'),
-) -> Union[Tensor, np.ndarray]:
+) -> Tensor | np.ndarray:
     x_tensor = torch.ones(shape, dtype=dtype, device=device)
     if out_t == 'tensor':
         return x_tensor
@@ -183,7 +183,7 @@ def dict_product(data):
         yield {**out_prod, **others}
 
 
-def load_config(filename: str) -> List[Dict[str, Any]]:
+def load_config(filename: str) -> list[dict[str, Any]]:
     with open(filename) as f:
         data = yaml.load(f, Loader=SafeLoader)
 
@@ -225,7 +225,7 @@ def _unpick(filename: str) -> list[Any]:
 
 
 def _build_kwargs(
-        f_kwargs: Dict[str, Any],
+        f_kwargs: dict[str, Any],
         out_t: str,
         dtype: torch.dtype = torch.float32,
         device: torch.device = torch.device('cpu'),
@@ -242,7 +242,7 @@ def _build_kwargs(
 
 
 def run(
-        configs: List[Dict[str, Any]],
+        configs: list[dict[str, Any]],
         output_filename: str,
         verbose: bool,
 ) -> int:
@@ -339,7 +339,7 @@ def run(
     return 0
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     argv = argv if argv is not None else sys.argv[1:]
     parser = argparse.ArgumentParser(
         prog='Performance kornia CLI',

--- a/dynamo/runner.py
+++ b/dynamo/runner.py
@@ -398,6 +398,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         '--save-graphs',
         action='store_true',
         default=False,
+        help=('From the benchmark file, generate a graph for each operation'
+              'comparing the benchmarks.')
     )
 
     _dt = datetime.strftime(datetime.utcnow(), '%Y%m%d_%H%M%S')


### PR DESCRIPTION
This patch aims to generate graphs from the benchmark results.

For this, we need to add:
- dynamo/compare.py - Rewrite part of the `Compare` and Table classes (from `torch.utils.benchmark.utils.compare`) to be able to parse into a CSV format to be able to use the results in other tools, as Pandas.
- dynamo/plot.py - functions to prepare the table, and perform the plot of the results.


For example, benchmarking the `geometry.transform.rescale` function (`$ python runner.py --save-graphs `)

### Config file:
```yaml
global:
  batch_sizes: [16]
  resolutions:
    [
      64,
      512
    ]
  threads:
    [
      1,
      8
    ]
  import_from: 'config'

geometry.transform.rescale:
  factor:
    [
      [0.5, 0.5],
      [1.5, 1.5]
    ]
```
### Torch `compare` results

```output
[-------------------------------------------- geometry.transform.rescale --------------------------------------------]
                             |  kornia_cpu  |  kornia_cuda  |  dynamo_kornia_cpu  |  dynamo_kornia_cuda  |  opencv_cpu
1 threads: -----------------------------------------------------------------------------------------------------------
      [16, 64, [0.5, 0.5]]   |      266.1   |      16.4     |          267.2      |         16.5         |     135.9  
      [16, 512, [0.5, 0.5]]  |    27334.6   |     159.2     |        26912.4      |        159.1         |    6728.7  
      [16, 64, [1.5, 1.5]]   |     1703.0   |      16.1     |         1698.0      |         16.1         |     451.5  
      [16, 512, [1.5, 1.5]]  |   176466.8   |     523.9     |       176901.1      |        523.3         |   28915.0  
8 threads: -----------------------------------------------------------------------------------------------------------
      [16, 64, [0.5, 0.5]]   |       89.3   |      16.5     |           93.9      |         16.4         |     135.9  
      [16, 512, [0.5, 0.5]]  |     2878.4   |     159.3     |         2882.0      |        159.1         |    6736.4  
      [16, 64, [1.5, 1.5]]   |      380.8   |      16.1     |          383.2      |         16.1         |     460.6  
      [16, 512, [1.5, 1.5]]  |    28722.3   |     524.2     |        28646.6      |        523.4         |   28918.5  

Times are in microseconds (us).
```

### The dataframe before plot

```output
optimizer                          opencv  eager_cpu  dynamo_cpu  eager_gpu  dynamo_gpu
label                                                                                  
8 threads\n[16, 64, [1.5, 1.5]]     460.6      380.8       383.2       16.1        16.1
8 threads\n[16, 64, [0.5, 0.5]]     135.9       89.3        93.9       16.5        16.4
8 threads\n[16, 512, [1.5, 1.5]]  28918.5    28722.3     28646.6      524.2       523.4
8 threads\n[16, 512, [0.5, 0.5]]   6736.4     2878.4      2882.0      159.3       159.1
1 threads\n[16, 64, [1.5, 1.5]]     451.5     1703.0      1698.0       16.1        16.1
1 threads\n[16, 64, [0.5, 0.5]]     135.9      266.1       267.2       16.4        16.5
1 threads\n[16, 512, [1.5, 1.5]]  28915.0   176466.8    176901.1      523.9       523.3
1 threads\n[16, 512, [0.5, 0.5]]   6728.7    27334.6     26912.4      159.2       159.1
```
### Graphs
For the graph time, small bars are better.
For the comparison graphs, bigger bars are better. And bar smaller than 1, means that it is slower than the comparison item

#### Time graph
![image](https://user-images.githubusercontent.com/20444345/224496404-4fb2e4fb-273a-4d0b-8b23-116e00ed1a18.png)

#### Ratio with OpenCV
![image](https://user-images.githubusercontent.com/20444345/224506523-618ec5af-ddcc-4396-9527-716106fd8270.png)

#### Ratio with eager CPU
![image](https://user-images.githubusercontent.com/20444345/224506547-da2d5762-e0b2-4c1e-9677-fd84e0692cf2.png)

#### Ratio with eager GPU
![image](https://user-images.githubusercontent.com/20444345/224506556-99aa2e3c-abd8-4fcd-b367-fcc97c1cb898.png)



