### PR TITLE
Add benchmark code for `filters`

### DIFF
--- a/dynamo/bench_config.yaml
+++ b/dynamo/bench_config.yaml
@@ -1,24 +1,24 @@
 global:
   batch_sizes:
     [
-      # 1,
+      1,
       # 2,
-      # 5,
-      9
+      5,
+      # 9
     ]
   resolutions:
     [
       # 32,
       # 64,
-      # 128,
-      # 256,
-      512
+      128,
+      256,
+      # 512
     ]
   threads:
     [
-      # 1,
+      1,
       # 4,
-      8
+      # 8
     ]
   import_from: 'config'
 
@@ -29,14 +29,14 @@ global:
 #       [0.5, 0.5],
 #       [1.5, 1.5]
 #     ]
-
+#
 # morphology.dilation:
 #   kernel:
 #     ones:
 #       [9, 9]
 #   engine: ['unfold', 'convolution']
-
-
+#
+#
 # morphology.erosion:
 #   kernel:
 #     ones:
@@ -48,34 +48,85 @@ global:
 #     ones:
 #       [9, 9]
 #   engine: ['unfold', 'convolution']
-
-
+#
+#
 # morphology.gradient:
 #   kernel:
 #     ones:
 #       [9, 9]
 #   engine: ['unfold', 'convolution']
-
+#
 # #
 # morphology.top_hat:
 #   kernel:
 #     ones:
 #       [9, 9]
 #   engine: ['unfold', 'convolution']
+#
+# color.multiple:
+#   mode:
+#     [
+#       'bgr_to_rgb',
+#       'rgb_to_grayscale',
+#       'rgb_to_hls',
+#       'rgb_to_hsv',
+#       'rgb_to_lab',
+#       'rgb_to_luv',
+#       'rgb_to_xyz',
+#       'rgb_to_ycbcr',
+#       'rgb_to_yuv',
+#     ]
+#
+# color.rgb_to_rgba:
+#   alpha_val: [1.0]
 
-color.multiple:
-  mode:
-    [
-      'bgr_to_rgb',
-      'rgb_to_grayscale',
-      'rgb_to_hls',
-      'rgb_to_hsv',
-      'rgb_to_lab',
-      'rgb_to_luv',
-      'rgb_to_xyz',
-      'rgb_to_ycbcr',
-      'rgb_to_yuv',
-    ]
+# filters.bilateral:
+#     kernel_size: [3, 25]
+#     sigma_color: [50.5,] # 1.5]
+#     sigma_space: [38.9,] # 2.7]
+#     # NOTE: OpenCV always perfom with "l1", "l2" is a matlab based implementation
+#     color_distance_type: ["l1", "l2"]
 
-color.rgb_to_rgba:
-  alpha_val: [1.0]
+# filters.gaussian:
+#     kernel_size: [3, 25]
+#     sigma: [[7.5, 10.5], [0.5, 0.75]] # 1.5]
+
+# filters.canny:
+#     # TODO: Inject config for generate the input info
+#     # CFG:
+#     #    max_img: 255
+#     #    cast: True
+#     low_threshold: [0.1, 0.5]
+#     high_threshold: [0.6, 0.9]
+#     kernel_size: [3, 25]
+
+# filters.laplacian:
+#     kernel_size: [3, 25]
+
+# filters.median_blur:
+#    kernel_size: [3, 25]
+
+# filters.sobel:
+#     no_args: true
+
+# filters.motion:
+#     kernel_size: [3, 25]
+#     angle: [120.0, -75.0]
+#     # TODO: add direction to do something on opencv case
+#     direction: [0.0]
+
+# filters.unsharp:
+#     kernel_size: [3, 25]
+#     sigma: [[1.5, 1.5], [75.5, 85.5]]
+
+filters.jointbilateral:
+    # NOTE: we should overwrite the resolution here to align with the guidance
+    batch_sizes: [2,]
+    resolutions: [128,]
+    guidance:
+        ones: [2, 3, 128, 128]
+    kernel_size: [3, 25]
+    sigma_color: [50.5,] # 1.5]
+    sigma_space: [38.9,] # 2.7]
+    # NOTE: OpenCV always perfom with "l1", "l2" is a matlab based implementation
+    color_distance_type: ["l1", "l2"]

--- a/dynamo/config/filters/bilateral.py
+++ b/dynamo/config/filters/bilateral.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import cv2
+import kornia
+import numpy as np
+from kornia.core import Tensor
+
+
+def kornia_op(
+        input: Tensor,
+        kernel_size: int,
+        sigma_color: float,
+        sigma_space: float,
+        color_distance_type: str,
+) -> None:
+    sig_sp = (sigma_space, sigma_space)
+    kornia.filters.bilateral.bilateral_blur(
+        input, kernel_size, sigma_color, sig_sp,
+        color_distance_type=color_distance_type,
+    )
+
+
+def opencv_op(
+        input: np.ndarray,
+        kernel_size: int,
+        sigma_color: float,
+        sigma_space: float,
+        color_distance_type: str,
+) -> None:
+    # simulate batch as sequential op
+    if len(input.shape) == 3:
+        input = input[None]
+
+    for i in range(input.shape[0]):
+        x = input[i]
+        cv2.bilateralFilter(x, kernel_size, sigma_color, sigma_space)

--- a/dynamo/config/filters/canny.py
+++ b/dynamo/config/filters/canny.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import cv2
+import kornia
+import numpy as np
+
+
+kornia_op = kornia.filters.canny
+
+
+def opencv_op(
+        input: np.ndarray,
+        low_threshold: float,
+        high_threshold: float,
+        kernel_size: int,
+) -> None:
+    # simulate batch as sequential op
+    if len(input.shape) == 3:
+        input = input[None]
+
+    # TODO: do this casting on the runner via config
+    input = (input * 255).astype(np.uint8)
+    low_threshold *= 255
+    high_threshold *= 255
+
+    for i in range(input.shape[0]):
+        x = input[i]
+        cv2.Canny(x, low_threshold, high_threshold, kernel_size)

--- a/dynamo/config/filters/gaussian.py
+++ b/dynamo/config/filters/gaussian.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import cv2
+import kornia
+import numpy as np
+from kornia.core import Tensor
+
+
+def kornia_op(
+        input: Tensor,
+        kernel_size: int,
+        sigma: list[float],
+) -> None:
+    kornia.filters.gaussian_blur2d(input, kernel_size, tuple(sigma))
+
+
+def opencv_op(
+        input: np.ndarray,
+        kernel_size: int,
+        sigma: list[float],
+) -> None:
+    # simulate batch as sequential op
+    if len(input.shape) == 3:
+        input = input[None]
+
+    k = (kernel_size, kernel_size)
+    for i in range(input.shape[0]):
+        x = input[i]
+        cv2.GaussianBlur(x, k, sigma[0], sigma[1])

--- a/dynamo/config/filters/jointbilateral.py
+++ b/dynamo/config/filters/jointbilateral.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import cv2
+import kornia
+import numpy as np
+from kornia.core import Tensor
+
+
+def kornia_op(
+        input: Tensor,
+        guidance: Tensor,
+        kernel_size: int,
+        sigma_color: float,
+        sigma_space: float,
+        color_distance_type: str,
+) -> None:
+    sig_sp = (sigma_space, sigma_space)
+    kornia.filters.bilateral.joint_bilateral_blur(
+        input, guidance, kernel_size, sigma_color, sig_sp,
+        color_distance_type=color_distance_type,
+    )
+
+
+def opencv_op(
+        input: np.ndarray,
+        guidance: np.ndarray,
+        kernel_size: int,
+        sigma_color: float,
+        sigma_space: float,
+        color_distance_type: str,
+) -> None:
+    # simulate batch as sequential op
+    if len(input.shape) == 3:
+        input = input[None]
+
+    # TODO: figure out to do this on the runner
+    guidance = np.moveaxis(guidance, 1, -1)
+
+    for i in range(input.shape[0]):
+        x = input[i]
+        g = guidance[i]
+        cv2.ximgproc.jointBilateralFilter(
+            g, x, kernel_size, sigma_color, sigma_space,
+        )

--- a/dynamo/config/filters/laplacian.py
+++ b/dynamo/config/filters/laplacian.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import cv2
+import kornia
+import numpy as np
+
+
+kornia_op = kornia.filters.laplacian
+
+
+def opencv_op(
+        input: np.ndarray,
+        kernel_size: int,
+) -> None:
+    # simulate batch as sequential op
+    if len(input.shape) == 3:
+        input = input[None]
+
+    # TODO: do this casting on the runner via config
+    input = (input * 255).astype(np.uint8)
+
+    for i in range(input.shape[0]):
+        x = input[i]
+        cv2.Laplacian(x, cv2.CV_16S, ksize=kernel_size)

--- a/dynamo/config/filters/median_blur.py
+++ b/dynamo/config/filters/median_blur.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import cv2
+import kornia
+import numpy as np
+
+
+kornia_op = kornia.filters.median_blur
+
+
+def opencv_op(
+        input: np.ndarray,
+        kernel_size: int,
+) -> None:
+    # simulate batch as sequential op
+    if len(input.shape) == 3:
+        input = input[None]
+
+    # TODO: do this casting on the runner via config
+    input = (input * 255).astype(np.uint8)
+
+    for i in range(input.shape[0]):
+        x = input[i]
+        cv2.medianBlur(x, ksize=kernel_size)

--- a/dynamo/config/filters/motion.py
+++ b/dynamo/config/filters/motion.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import cv2
+import kornia
+import numpy as np
+
+
+kornia_op = kornia.filters.motion_blur
+
+
+def opencv_op(
+        input: np.ndarray,
+        kernel_size: int,
+        angle: float,
+        direction: float = 0.0,
+) -> None:
+    # simulate batch as sequential op
+    if len(input.shape) == 3:
+        input = input[None]
+
+    k = np.zeros((kernel_size, kernel_size), dtype=np.float32)
+    k[(kernel_size-1) // 2, :] = np.ones(kernel_size, dtype=np.float32)
+    k = cv2.warpAffine(
+        k, cv2.getRotationMatrix2D(
+            (kernel_size / 2 - 0.5, kernel_size / 2 - 0.5), angle, 1.0,
+        ),
+        (kernel_size, kernel_size),
+    )
+    k = k * (1.0 / np.sum(k))
+
+    for i in range(input.shape[0]):
+        x = input[i]
+        cv2.filter2D(x, -1, k)

--- a/dynamo/config/filters/sobel.py
+++ b/dynamo/config/filters/sobel.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import cv2
+import kornia
+import numpy as np
+
+
+kornia_op = kornia.filters.sobel
+
+
+def opencv_op(
+        input: np.ndarray,
+) -> None:
+    # simulate batch as sequential op
+    if len(input.shape) == 3:
+        input = input[None]
+
+    for i in range(input.shape[0]):
+        x = input[i]
+        cv2.Sobel(x, cv2.CV_64F, dx=1, dy=1, ksize=3)

--- a/dynamo/config/filters/unsharp.py
+++ b/dynamo/config/filters/unsharp.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import cv2
+import kornia
+import numpy as np
+from kornia.core import Tensor
+
+
+def kornia_op(
+        input: Tensor,
+        kernel_size: int,
+        sigma: tuple[float, float]
+) -> None:
+
+    kornia.filters.unsharp_mask(input, kernel_size, tuple(sigma))
+
+
+def opencv_op(
+        input: np.ndarray,
+        kernel_size: int,
+        sigma: tuple[float, float]
+) -> None:
+    # simulate batch as sequential op
+    if len(input.shape) == 3:
+        input = input[None]
+
+    k = (kernel_size, kernel_size)
+    for i in range(input.shape[0]):
+        x = input[i]
+        data_blur = cv2.GaussianBlur(x, k, sigma[0], sigma[1])
+        _ = x + (x - data_blur)

--- a/dynamo/plot.py
+++ b/dynamo/plot.py
@@ -83,6 +83,7 @@ def _plot_time_graph(
     name: str = 'My graph',
     time_unit: str = '',
 ) -> plt.Axes:
+    h_fig = max(len(df)/2, 10.)
     ax = df.plot.barh(
         color=colors,
         legend=True,
@@ -90,6 +91,8 @@ def _plot_time_graph(
         width=0.8,
         align='center',
         logx=True,
+        figsize=(10.0, h_fig),
+
     )
     ax.invert_yaxis()
     ax.margins(0.1)
@@ -120,11 +123,13 @@ def _plot_ratio_graph(
     colors: list[tuple[float, ...]],
     name: str = 'My ratio graph',
 ) -> plt.Axes:
+    h_fig = max(len(df)/2, 10.)
     ax = df.plot.barh(
         color=colors,
         legend=True,
         width=0.8,
         align='center',
+        figsize=(10.0, h_fig),
     )
     ax.invert_yaxis()
     ax.margins(0.1)

--- a/dynamo/requirements.txt
+++ b/dynamo/requirements.txt
@@ -2,6 +2,7 @@
 # torch[dynamo]
 kornia@git+https://github.com/kornia/kornia
 matplotlib
+opencv-contrib-python
 opencv-python
 pandas
 PyYAML

--- a/dynamo/runner.py
+++ b/dynamo/runner.py
@@ -60,11 +60,9 @@ def create_inputs(
         device: torch.device = torch.device('cpu'),
         RGB: bool = True,
 ) -> Tensor | np.ndarray:
-
+    shape = (bs, 3, res, res) if isinstance(bs, int) else (3, res, res)
     if RGB:
-        x_tensor = torch.ones((3, res, res), dtype=dtype, device=device)
-        if bs is not None:
-            x_tensor = x_tensor[None].repeat(bs, 1, 1, 1)
+        x_tensor = torch.rand(shape, dtype=dtype, device=device)
     else:
         # TODO
         raise NotImplementedError
@@ -73,6 +71,7 @@ def create_inputs(
         return x_tensor
 
     x_array: np.ndarray = x_tensor.detach().cpu().numpy()
+    x_array = np.moveaxis(x_array, 1, -1)
     return x_array
 
 
@@ -205,7 +204,7 @@ def load_config(filename: str) -> list[dict[str, Any]]:
         for lc in dict_product(
             {
                 cn: _unpack_config(cv) for cn, cv in v.items()
-                if cv not in DEFAULT_CONFIGS and cn != 'no_args'
+                if cn not in DEFAULT_CONFIGS and cn != 'no_args'
             },
         )
     ]
@@ -406,6 +405,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         sig = generate_graphs(filename=args.output_filename)
 
     return sig
+
 
 if __name__ == '__main__':
     raise SystemExit(main())


### PR DESCRIPTION
This should be rebased after #8 is merged.

This patch should add the benchmark cases for the `filters` module. starts from https://github.com/kornia/kornia-benchmark/pull/10/commits/b39c0bd07d704547c239a6197b716c6a45c167b1

- [x] bilateral
- [x] gaussian
- [x] canny
- [x] laplacian
- [x] median blur
- [x] sobel
- [x] motion
- [x] unsharp
- [x] jointBilateral