### PR TITLE
Add config option to define the `maxvalue` and `dtype`

### DIFF
--- a/dynamo/bench_config.yaml
+++ b/dynamo/bench_config.yaml
@@ -2,23 +2,23 @@ global:
   batch_sizes:
     [
       1,
-      2,
-      5,
-      9
+      # 2,
+      # 5,
+      # 9
     ]
   resolutions:
     [
-      32,
-      # 64,
+      # 32,
+      64,
       # 128,
-      256,
+      # 256,
       # 512
     ]
   threads:
     [
       1,
       # 4,
-      8
+      # 8
     ]
   import_from: 'config'
   np_dtype: float32
@@ -32,40 +32,42 @@ global:
 #       [0.5, 0.5],
 #       [1.5, 1.5]
 #     ]
+#
+# morphology.dilation:
+#   # np_dtype: uint8
+#   # np_maxvalue: 255
+#   kernel:
+#     ones:
+#       [9, 9]
+#   engine: ['unfold', 'convolution']
+#
+#
+# morphology.erosion:
+#   kernel:
+#     ones:
+#       [9, 9]
+#   engine: ['unfold', 'convolution']
 
-morphology.dilation:
-  # np_dtype: uint8
-  # np_maxvalue: 255
-  kernel:
-    ones:
-      [25, 25]
-  engine: ['unfold', 'convolution']
-
-morphology.erosion:
-  kernel:
-    ones:
-      [25, 25]
-  engine: ['unfold', 'convolution']
-
-morphology.closing:
-  kernel:
-    ones:
-      [25, 25]
-  engine: ['unfold', 'convolution']
-
-
-morphology.gradient:
-  kernel:
-    ones:
-      [25, 25]
-  engine: ['unfold', 'convolution']
-
-morphology.top_hat:
-  kernel:
-    ones:
-      [25, 25]
-  engine: ['unfold', 'convolution']
-
+# morphology.closing:
+#   kernel:
+#     ones:
+#       [9, 9]
+#   engine: ['unfold', 'convolution']
+#
+#
+# morphology.gradient:
+#   kernel:
+#     ones:
+#       [9, 9]
+#   engine: ['unfold', 'convolution']
+#
+# #
+# morphology.top_hat:
+#   kernel:
+#     ones:
+#       [9, 9]
+#   engine: ['unfold', 'convolution']
+#
 # color.multiple:
 #   mode:
 #     [
@@ -122,17 +124,17 @@ morphology.top_hat:
 #     kernel_size: [3, 25]
 #     sigma: [[1.5, 1.5], [75.5, 85.5]]
 
-# filters.jointbilateral:
-#     # NOTE: we should overwrite the resolution here to align with the guidance
-#     batch_sizes: [2,]
-#     resolutions: [128,]
-#     guidance:
-#         ones: [2, 3, 128, 128]
-#     kernel_size: [3, 25]
-#     sigma_color: [50.5,] # 1.5]
-#     sigma_space: [38.9,] # 2.7]
-#     # NOTE: OpenCV always perfom with "l1", "l2" is a matlab based implementation
-#     color_distance_type: ["l1", "l2"]
+filters.jointbilateral:
+    # NOTE: we should overwrite the resolution here to align with the guidance
+    batch_sizes: [2,]
+    resolutions: [128,]
+    guidance:
+        ones: [2, 3, 128, 128]
+    kernel_size: [3, 25]
+    sigma_color: [50.5,] # 1.5]
+    sigma_space: [38.9,] # 2.7]
+    # NOTE: OpenCV always perfom with "l1", "l2" is a matlab based implementation
+    color_distance_type: ["l1", "l2"]
 
 augmentation.multiple:
   mode:

--- a/dynamo/bench_config.yaml
+++ b/dynamo/bench_config.yaml
@@ -2,26 +2,29 @@ global:
   batch_sizes:
     [
       1,
-      # 2,
-      # 5,
-      # 9
+      2,
+      5,
+      9
     ]
   resolutions:
     [
-      # 32,
-      64,
+      32,
+      # 64,
       # 128,
-      # 256,
+      256,
       # 512
     ]
   threads:
     [
       1,
       # 4,
-      # 8
+      8
     ]
   import_from: 'config'
-
+  np_dtype: float32
+  np_maxvalue: 1.0
+  torch_dtype: float32
+  torch_maxvalue: 1.0
 
 # geometry.transform.rescale:
 #   factor:
@@ -29,40 +32,40 @@ global:
 #       [0.5, 0.5],
 #       [1.5, 1.5]
 #     ]
-#
-# morphology.dilation:
-#   kernel:
-#     ones:
-#       [9, 9]
-#   engine: ['unfold', 'convolution']
-#
-#
-# morphology.erosion:
-#   kernel:
-#     ones:
-#       [9, 9]
-#   engine: ['unfold', 'convolution']
 
-# morphology.closing:
-#   kernel:
-#     ones:
-#       [9, 9]
-#   engine: ['unfold', 'convolution']
-#
-#
-# morphology.gradient:
-#   kernel:
-#     ones:
-#       [9, 9]
-#   engine: ['unfold', 'convolution']
-#
-# #
-# morphology.top_hat:
-#   kernel:
-#     ones:
-#       [9, 9]
-#   engine: ['unfold', 'convolution']
-#
+morphology.dilation:
+  # np_dtype: uint8
+  # np_maxvalue: 255
+  kernel:
+    ones:
+      [25, 25]
+  engine: ['unfold', 'convolution']
+
+morphology.erosion:
+  kernel:
+    ones:
+      [25, 25]
+  engine: ['unfold', 'convolution']
+
+morphology.closing:
+  kernel:
+    ones:
+      [25, 25]
+  engine: ['unfold', 'convolution']
+
+
+morphology.gradient:
+  kernel:
+    ones:
+      [25, 25]
+  engine: ['unfold', 'convolution']
+
+morphology.top_hat:
+  kernel:
+    ones:
+      [25, 25]
+  engine: ['unfold', 'convolution']
+
 # color.multiple:
 #   mode:
 #     [
@@ -119,17 +122,17 @@ global:
 #     kernel_size: [3, 25]
 #     sigma: [[1.5, 1.5], [75.5, 85.5]]
 
-filters.jointbilateral:
-    # NOTE: we should overwrite the resolution here to align with the guidance
-    batch_sizes: [2,]
-    resolutions: [128,]
-    guidance:
-        ones: [2, 3, 128, 128]
-    kernel_size: [3, 25]
-    sigma_color: [50.5,] # 1.5]
-    sigma_space: [38.9,] # 2.7]
-    # NOTE: OpenCV always perfom with "l1", "l2" is a matlab based implementation
-    color_distance_type: ["l1", "l2"]
+# filters.jointbilateral:
+#     # NOTE: we should overwrite the resolution here to align with the guidance
+#     batch_sizes: [2,]
+#     resolutions: [128,]
+#     guidance:
+#         ones: [2, 3, 128, 128]
+#     kernel_size: [3, 25]
+#     sigma_color: [50.5,] # 1.5]
+#     sigma_space: [38.9,] # 2.7]
+#     # NOTE: OpenCV always perfom with "l1", "l2" is a matlab based implementation
+#     color_distance_type: ["l1", "l2"]
 
 augmentation.multiple:
   mode:

--- a/dynamo/config/morphology/bottom_hat.py
+++ b/dynamo/config/morphology/bottom_hat.py
@@ -2,7 +2,7 @@ import cv2
 import kornia
 import numpy as np
 
-kornia_op =  kornia.morphology.bottom_hat
+kornia_op = kornia.morphology.bottom_hat
 
 
 def opencv_op(
@@ -12,7 +12,6 @@ def opencv_op(
         **kwargs
 ) -> None:
     # simulate batch as sequential op
-    input = input.astype(np.uint8)
     kernel = kernel.astype(np.uint8)
     if len(input.shape) == 3:
         input = input[None]

--- a/dynamo/config/morphology/closing.py
+++ b/dynamo/config/morphology/closing.py
@@ -5,7 +5,6 @@ import numpy as np
 kornia_op = kornia.morphology.closing
 
 
-
 def opencv_op(
         input: np.ndarray,
         kernel: np.ndarray,
@@ -13,7 +12,6 @@ def opencv_op(
         **kwargs
 ) -> None:
     # simulate batch as sequential op
-    input = input.astype(np.uint8)
     kernel = kernel.astype(np.uint8)
     if len(input.shape) == 3:
         input = input[None]

--- a/dynamo/config/morphology/dilation.py
+++ b/dynamo/config/morphology/dilation.py
@@ -2,7 +2,7 @@ import cv2
 import kornia
 import numpy as np
 
-kornia_op =  kornia.morphology.dilation
+kornia_op = kornia.morphology.dilation
 
 
 def opencv_op(
@@ -12,8 +12,8 @@ def opencv_op(
         **kwargs
 ) -> None:
     # simulate batch as sequential op
-    input = input.astype(np.uint8)
     kernel = kernel.astype(np.uint8)
+
     if len(input.shape) == 3:
         input = input[None]
 

--- a/dynamo/config/morphology/erosion.py
+++ b/dynamo/config/morphology/erosion.py
@@ -12,7 +12,6 @@ def opencv_op(
         **kwargs
 ) -> None:
     # simulate batch as sequential op
-    input = input.astype(np.uint8)
     kernel = kernel.astype(np.uint8)
     if len(input.shape) == 3:
         input = input[None]

--- a/dynamo/config/morphology/gradient.py
+++ b/dynamo/config/morphology/gradient.py
@@ -12,7 +12,6 @@ def opencv_op(
         **kwargs
 ) -> None:
     # simulate batch as sequential op
-    input = input.astype(np.uint8)
     kernel = kernel.astype(np.uint8)
     if len(input.shape) == 3:
         input = input[None]

--- a/dynamo/config/morphology/top_hat.py
+++ b/dynamo/config/morphology/top_hat.py
@@ -2,7 +2,7 @@ import cv2
 import kornia
 import numpy as np
 
-kornia_op =kornia.morphology.top_hat
+kornia_op = kornia.morphology.top_hat
 
 
 def opencv_op(
@@ -12,7 +12,6 @@ def opencv_op(
         **kwargs
 ) -> None:
     # simulate batch as sequential op
-    input = input.astype(np.uint8)
     kernel = kernel.astype(np.uint8)
     if len(input.shape) == 3:
         input = input[None]


### PR DESCRIPTION
This patch introduces the options:
- `torch_maxvalue` and `np_maxvalue` to define the maxvalue of the input random generated for the benchmarks
- `torch_dtype` and `np_dtype` to define the dtype of the input random generated for the benchmarks

These config are part of the global config of benchmark cases, which can be replaced in each config scope 